### PR TITLE
Fix image path and bullet state comparisons

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -23,7 +23,7 @@ icon = pygame.image.load('ufo.png')
 pygame.display.set_icon(icon)
 
 # Player
-playerImg = pygame.image.load('player.png')
+playerImg = pygame.image.load('Player.png')
 playerX = 370
 playerY = 480
 playerX_change = 0
@@ -118,7 +118,7 @@ while running:
             if event.key == pygame.K_RIGHT:
                 playerX_change = 5
             if event.key == pygame.K_SPACE:
-                if bullet_state is "ready":
+                if bullet_state == "ready":
                     bulletSound = mixer.Sound("laser.wav")
                     bulletSound.play()
                     # Get the current x cordinate of the spaceship
@@ -174,7 +174,7 @@ while running:
         bulletY = 480
         bullet_state = "ready"
 
-    if bullet_state is "fire":
+    if bullet_state == "fire":
         fire_bullet(bulletX, bulletY)
         bulletY -= bulletY_change
 


### PR DESCRIPTION
## Summary
- use correct case when loading `Player.png`
- use `==` instead of `is` for bullet state checks

## Testing
- `python -m py_compile Main.py`

------
https://chatgpt.com/codex/tasks/task_e_68764d91d7c083218273b5d4c67d1fe3